### PR TITLE
Fix WSGI application path

### DIFF
--- a/ISLab/settings.py
+++ b/ISLab/settings.py
@@ -58,7 +58,7 @@ TEMPLATES = [
     },
 ]
 
-WSGI_APPLICATION = 'ISlab.wsgi.application'
+WSGI_APPLICATION = 'ISLab.wsgi.application'
 
 
 # Database


### PR DESCRIPTION
## Summary
- fix the case of the module name in `WSGI_APPLICATION`

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ed99898832e8779b65e82403045