### PR TITLE
Add API tests for remaining endpoints

### DIFF
--- a/ISLab/settings_test.py
+++ b/ISLab/settings_test.py
@@ -1,0 +1,8 @@
+from .settings import *
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}

--- a/apps/api/tests/test_news_api.py
+++ b/apps/api/tests/test_news_api.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class NewsAPITestCase(APITestCase):
+    def test_news_list_returns_200(self):
+        url = reverse('news-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/apps/api/tests/test_projects_api.py
+++ b/apps/api/tests/test_projects_api.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class ProjectsAPITestCase(APITestCase):
+    def test_projects_list_returns_200(self):
+        url = reverse('project-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/apps/api/tests/test_publications_api.py
+++ b/apps/api/tests/test_publications_api.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class PublicationsAPITestCase(APITestCase):
+    def test_publications_list_returns_200(self):
+        url = reverse('publication-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/apps/api/tests/test_staff_api.py
+++ b/apps/api/tests/test_staff_api.py
@@ -1,0 +1,9 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+class StaffAPITestCase(APITestCase):
+    def test_staff_list_returns_200(self):
+        url = reverse('staff-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- cover other API viewsets with basic tests
- switch existing news API test to named URL

## Testing
- `python manage.py test --settings=ISLab.settings_test`

------
https://chatgpt.com/codex/tasks/task_e_683f606db864832e8cf28ffa0a94da72