### PR TITLE
Add admin interface theme

### DIFF
--- a/ISLab/settings.py
+++ b/ISLab/settings.py
@@ -16,6 +16,8 @@ ALLOWED_HOSTS = config('DJANGO_ALLOWED_HOSTS', default='*').split(',')
 
 # Application definition
 INSTALLED_APPS = [
+    'admin_interface',
+    'colorfield',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -128,3 +130,7 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 4,  # в ответе приходит { count, next, previous, results }
 }
+
+# Django-admin-interface settings
+X_FRAME_OPTIONS = "SAMEORIGIN"
+SILENCED_SYSTEM_CHECKS = ["security.W019"]

--- a/ISLab/urls.py
+++ b/ISLab/urls.py
@@ -1,4 +1,8 @@
 from django.contrib import admin
+
+admin.site.site_header = "ISLab Administration"
+admin.site.site_title = "ISLab Admin Portal"
+admin.site.index_title = "Welcome to ISLab Admin"
 from django.urls import path, include
 from django.views.generic import TemplateView
 from rest_framework.routers import DefaultRouter

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ $ source venv/bin/activate  # Windows: venv\Scripts\activate
 # 3. Ставим зависимости
 $ pip install -r requirements.txt
 ```
+В список зависимостей входит пакет `django-admin-interface`, обеспечивающий оформление панели администратора.
 
 Создайте базу данных и пользователя MySQL:
 
@@ -193,6 +194,12 @@ $ docker-compose down -v
 * **Публикации**: поля *Название*, *Авторы*, *Журнал*, *Ссылка*.
 * **Сотрудники**: фотография, контакты, краткая биография.
 * **Проекты**: период выполнения, цель, результаты, заказчик.
+
+### Настройка темы администратора
+
+Панель управления оформлена с помощью [django-admin-interface](https://github.com/fabiocaccamo/django-admin-interface).
+Приложения `admin_interface` и `colorfield` уже добавлены в `INSTALLED_APPS`, а заголовки панели задаются в [`ISLab/urls.py`](ISLab/urls.py).
+При необходимости можно изменить шаблон `templates/admin/base_site.html` и стили `static/css/admin_custom.css`.
 
 ## Тестирование
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ pillow>=10.0.0                  # Для ImageField
 django-tailwind>=3.5.1          # Tailwind CSS через Django
 django-browser-reload>=1.11.0   # Автоперезагрузка страниц
 
+# Админ‑тема
+django-admin-interface>=0.30
+
 # Статические файлы
 whitenoise>=6.5.0               # Для обслуживания static в production
 

--- a/static/css/admin_custom.css
+++ b/static/css/admin_custom.css
@@ -1,0 +1,2 @@
+/* Custom admin styles */
+

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,14 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block title %}ISLab Admin{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static 'css/admin_custom.css' %}">
+{% endblock %}
+
+{% block branding %}
+    <h1 id="site-name"><a href="{% url 'admin:index' %}">ISLab Admin</a></h1>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- install `django-admin-interface`
- enable `admin_interface` in INSTALLED_APPS with required settings
- customize admin headers via `urls.py`
- override base admin template and add custom CSS
- document the admin theme setup in README

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684036c03e4c832ebbaaf9b9daa5dd08