### PR TITLE
Remove contacts section and display 3-column news

### DIFF
--- a/apps/api/pagination.py
+++ b/apps/api/pagination.py
@@ -1,0 +1,5 @@
+from rest_framework.pagination import PageNumberPagination
+
+class NewsPagination(PageNumberPagination):
+    page_size = 6
+

--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -1,6 +1,8 @@
 from django.shortcuts import render
 from rest_framework import viewsets, permissions
 
+from .pagination import NewsPagination
+
 from .serializers import NewsSerializer, ProjectSerializer, PublicationSerializer, StaffSerializer
 from apps.news.models import News
 from apps.projects.models import Project
@@ -16,6 +18,7 @@ class NewsViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = News.objects.all().order_by("-date")
     serializer_class = NewsSerializer
     permission_classes = [permissions.AllowAny]
+    pagination_class = NewsPagination
 
 
 class ProjectViewSet(viewsets.ReadOnlyModelViewSet):

--- a/templates/index.html
+++ b/templates/index.html
@@ -121,57 +121,19 @@
         </div>
     </section>
 
-    <!-- News and Contacts -->
+    <!-- News Section -->
     <section class="py-16 bg-gray-50">
         <div class="container mx-auto px-4">
-            <div class="flex flex-col lg:flex-row gap-8">
-                <!-- News Section -->
-                <div class="lg:w-2/3">
-                    <h3 class="text-2xl font-bold mb-6 section-title">Новости и события</h3>
-                    <div class="grid md:grid-cols-2 gap-6" id="news-container">
-                        <!-- News will be loaded here by JavaScript -->
-                    </div>
-                    <div class="mt-8 text-center">
-                        <button id="load-more-news"
-                                class="bg-primary-900 text-white px-6 py-2 rounded-lg hover:bg-primary-700 transition">
-                            Показать больше
-                        </button>
-                    </div>
+            <div>
+                <h3 class="text-2xl font-bold mb-6 section-title">Новости и события</h3>
+                <div class="grid md:grid-cols-3 gap-6" id="news-container">
+                    <!-- News will be loaded here by JavaScript -->
                 </div>
-
-                <!-- Contacts Section -->
-                <div class="lg:w-1/3">
-                    <h3 class="text-2xl font-bold mb-6 section-title">Контакты</h3>
-                    <div class="bg-white p-6 rounded-lg shadow-md">
-                        <div class="mb-4 flex items-start">
-                            <i class="fas fa-map-marker-alt text-primary-900 mt-1 mr-3"></i>
-                            <div>
-                                <h4 class="font-medium">Адрес</h4>
-                                <p class="text-gray-600">г. Москва, ул. Автозаводская, 16</p>
-                            </div>
-                        </div>
-                        <div class="mb-4 flex items-start">
-                            <i class="fas fa-phone-alt text-primary-900 mt-1 mr-3"></i>
-                            <div>
-                                <h4 class="font-medium">Телефон</h4>
-                                <p class="text-gray-600">+7 (495) 223-05-23</p>
-                            </div>
-                        </div>
-                        <div class="mb-4 flex items-start">
-                            <i class="fas fa-envelope text-primary-900 mt-1 mr-3"></i>
-                            <div>
-                                <h4 class="font-medium">Email</h4>
-                                <p class="text-gray-600">cybersec@mospolytech.ru</p>
-                            </div>
-                        </div>
-                        <div class="flex items-start">
-                            <i class="fas fa-clock text-primary-900 mt-1 mr-3"></i>
-                            <div>
-                                <h4 class="font-medium">Часы работы</h4>
-                                <p class="text-gray-600">Пн-Пт: 9:00 - 18:00</p>
-                            </div>
-                        </div>
-                    </div>
+                <div class="mt-8 text-center">
+                    <button id="load-more-news"
+                            class="bg-primary-900 text-white px-6 py-2 rounded-lg hover:bg-primary-700 transition">
+                        Показать больше
+                    </button>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- remove Contacts block from the news/contacts section
- show news cards in three columns
- return 6 news items per API page without changing other endpoints

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_684196b36f14832ea099b4cd4d79790a